### PR TITLE
update _config.yml to remove `collections: null`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ destination: ./_site
 plugins_dir:     ./_plugins
 layouts_dir:     ./_layouts
 data_dir: ./_data
-collections: null
+# collections: null
 
 # Handling Reading
 safe:         false


### PR DESCRIPTION
this option was included in `_config.yml` to document the key, but results in some jekyll behavior that was a bit confusing to debug.

see issues #4 and #5 
