### PR TITLE
Fixed the Jekyll Syntax Highlighter Warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,13 +60,13 @@ kramdown:
   smart_quotes:   lsquo,rsquo,ldquo,rdquo
   enable_coderay: false
 
-  coderay:
-    coderay_wrap:              div
-    coderay_line_numbers:      inline
-    coderay_line_number_start: 1
-    coderay_tab_width:         4
-    coderay_bold_every:        10
-    coderay_css:               style
+  syntax_highlighter_opts:
+    wrap:              div
+    line_numbers:      inline
+    line_number_start: 1
+    tab_width:         4
+    bold_every:        10
+    css:               style
 
 
 include: ['_pages']


### PR DESCRIPTION
Updated the config to resolve the deprecated option warning Jekyll was throwing at build about "syntax_highlighter_opts". The back story is that Kramdown now supports multiple syntax highlighters so they made the config more generic. This patch updates the options to support the new format.